### PR TITLE
Fixed 40yd range check bug in localized clients

### DIFF
--- a/sRaidFrames/sRaidFrames.lua
+++ b/sRaidFrames/sRaidFrames.lua
@@ -93,7 +93,7 @@ sRaidFrames.NextScan = 0
 sRaidFrames.MapScale = 0
 
 
-sRaidFrames.ClassSpellArray = {Paladin = "Holy Light", Priest = "Flash Heal", Druid = "Healing Touch", Shaman = "Healing Wave"}
+sRaidFrames.ClassSpellArray = {Paladin = BS["Holy Light"], Priest = BS["Flash Heal"], Druid = BS["Healing Touch"], Shaman = BS["Healing Wave"]}
 
 
 function sRaidFrames:OnInitialize()
@@ -642,7 +642,7 @@ function sRaidFrames:RangeCheck()
 	end	
 	--DEFAULT_CHAT_FRAME:AddMessage("|cff00eeeeDebug: |cffffffffRange Check")
 	if not self.ClassCheck then 
-		self.ClassCheck = UnitClass("player") 
+		self.ClassCheck = Zorlen_UnitClass("player") 
 		self.SpellCheck = self.ClassSpellArray[self.ClassCheck]
 	end
 	


### PR DESCRIPTION
Fixed 40yd range check bug occuring in non-english clients:
- added localization to hardcoded SpellCheck spells
- updatet UnitClass function to a Zorlen variant that includes localization support

Note: There are many other occurences of the UnitClass function without Zorlen and hence without localization. I haven't checked if this is correct for all cases as no other major bugs occured ...
